### PR TITLE
Fix HiDPI rendering for SVG icons

### DIFF
--- a/src/contents/ui/Exchange.qml
+++ b/src/contents/ui/Exchange.qml
@@ -247,6 +247,11 @@ Item {
             Layout.minimumHeight: 20
             Layout.maximumWidth: 20
             Layout.maximumHeight: 20
+            fillMode: Image.PreserveAspectFit
+            smooth: true
+            mipmap: true
+            sourceSize.width: Math.ceil(width * Screen.devicePixelRatio)
+            sourceSize.height: Math.ceil(height * Screen.devicePixelRatio)
             source: crypto ? Qt.resolvedUrl('../images/' + Crypto.getCryptoIcon(crypto)) : ''
         }
 


### PR DESCRIPTION
  ## Summary
  - Render crypto SVG icons with an explicit HiDPI-aware `sourceSize`
  - Preserve icon aspect ratio and enable smoothing/mipmaps
  - Improves tray/panel icon sharpness compared with native Plasma icons

  ## Notes
  Qt Quick rasterizes SVGs when loaded. Without an explicit `sourceSize`, the loaded texture can be too
  small and then scaled by the panel, resulting in pixelated icons on Hi-res displays.
  
  ## Before/After
  
<img width="102" height="68" alt="before-after-widget-small" src="https://github.com/user-attachments/assets/7e0a55b1-b583-444a-9462-694b730a1b49" />
